### PR TITLE
Preventing >> from becoming »

### DIFF
--- a/_commands/scripting/>>.md
+++ b/_commands/scripting/>>.md
@@ -4,7 +4,7 @@
 \>\>    {#appendOperator}
 -----
 
-'>>' is a shell operator that you can use to append the output in an existing file.
+'&gt;&gt;' is a shell operator that you can use to append the output in an existing file.
 
 ~~~ bash
 $ echo line 1 >> example.txt


### PR DESCRIPTION
By escaping the two greater than characters, hopefully it'll prevent markdown from rendering >> as »

(Granted the operator could also just be rendered as an inline code snippet, but I got the impression only "actual" commands were presented as such)

# ~Advanced HW 5 submission~ not actually adv hw 5 submission

~Closes #[your issue claim number]~ this wasn't an issue anyone brought up, just one I noticed myself

Name: Christina Liu
Uniqname: cyanliu

(on a side note I still can't develop locally and I'll still be stopping by OH sometime tonight)
